### PR TITLE
Update hero image for mobile view

### DIFF
--- a/src/partials/hero.html
+++ b/src/partials/hero.html
@@ -37,7 +37,7 @@
         media="(max-width: 767px)"
       />
       <img
-        src="./img/hero/hero-img-desk.webp"
+        src="./img/hero/hero-img-mob.webp"
         class="hero-img"
         alt="Banner with a list of artists"
         fetchpriority="high"


### PR DESCRIPTION
Changed the hero image source for screens up to 767px to use the mobile-specific image instead of the desktop version.